### PR TITLE
Fix sql and none check

### DIFF
--- a/resources/chrome_cookie.py
+++ b/resources/chrome_cookie.py
@@ -87,9 +87,9 @@ def insert_netflix_id(conn, name, expires_utc, last_access_utc, cookie_data, onl
 
 def clear_netflix_cookies(conn):
     try:
-        sql = 'DELETE cookies where host_key = ?'
+        sql = 'DELETE FROM cookies where host_key = ?'
         cur = conn.cursor()
-        cur.execute(sql, '.netflix.com')
+        cur.execute(sql, ('.netflix.com',))
         conn.commit()
     except: generic_utility.log('Error clearing Chrome-Cookie: ' +traceback.format_exc(), xbmc.LOGERROR)
 

--- a/resources/list.py
+++ b/resources/list.py
@@ -108,7 +108,7 @@ def add_videos_to_directory(loading_progress, run_as_widget, video_metadatas, vi
     else:
         xbmcplugin.addSortMethod(plugin_handle, xbmcplugin.SORT_METHOD_LABEL)
     
-    if (not url or 'list_viewing_activity' not in url) and len(video_metadatas) == items_per_page:
+    if page is not None and (not url or 'list_viewing_activity' not in url) and len(video_metadatas) == items_per_page:
         add.add_next_item(page + 1, url, video_type, 'list_videos')
 
 


### PR DESCRIPTION
Ok, so I finally sat down last night and tried to debug this. I'm fairly unfamiliar with the code so I had to make a few guesses. If you take a look at http://paste.ubuntu.com/23065122/ you'll see another error: `OperationalError: near "cookies": syntax error` which is caused by malformed SQL. Easy enough to fix but what I didn't understand is the `add_videos_to_directory`. It has an optional parameter `page = None` but the last line of that method has `page + 1` which also throws an error.

This pull request fixes those errors (which fixed the `root_list_id` for me). There are still some wonky things like 403 errors that just go away with a few attempts but I'll need some help debugging those.