### PR TITLE
Fix OpenELEC cookie file path

### DIFF
--- a/resources/chrome_cookie.py
+++ b/resources/chrome_cookie.py
@@ -111,7 +111,7 @@ def connect():
     else:
         db_path += '/.config/google-chrome/Default/Cookies'
         if not os.path.isfile(db_path):
-            db_path += '/storage/.kodi/userdata/addon_data/browser.chromium/profile'
+            db_path = '/storage/.kodi/userdata/addon_data/browser.chromium/profile/Default/Cookies'
 
     if not os.path.isfile(db_path):
         raise ValueError('Cannot find cookie-file in: '+db_path)


### PR DESCRIPTION
The logic for locating the Cookies file on OpenELEC would wind up trying to open `/storage/.config/google-chrome/Default/Cookies/storage/.kodi/userdata/addon_data/browser.chromium/profile/Default/Coories`.