### PR TITLE
Support beta and unstable Google Chrome channels

### DIFF
--- a/resources/chrome_cookie.py
+++ b/resources/chrome_cookie.py
@@ -109,8 +109,13 @@ def connect():
     elif generic_utility.darwin():
         db_path += "/Library/Application Support/Google/Chrome/Default/Cookies"
     else:
-        db_path += '/.config/google-chrome/Default/Cookies'
-        if not os.path.isfile(db_path):
+        chrome_channels = [ '', '-beta', '-unstable' ]
+        for channel in chrome_channels:
+            db_path_tmp = "%s/.config/google-chrome%s/Default/Cookies" % (db_path, channel)
+            if os.path.isfile(db_path_tmp):
+               db_path = db_path_tmp
+               break
+        else:
             db_path = '/storage/.kodi/userdata/addon_data/browser.chromium/profile/Default/Cookies'
 
     if not os.path.isfile(db_path):


### PR DESCRIPTION
When Google Chrome beta or unstable is installed, their cookies are not properly detected.
This PR checks for these browser variants/channels as well (in order of: stable, beta, unstable)

Additionally, the fallback `/storage/.kodi/userdata/addon_data/browser.chromium/profile/Default/Cookies` does not make sense (as I do not think people have a `storage` directory in their filesystem root?). Is it intended to use `db_path + /.kodi/userdata/addon_data/browser.chromium/profile/Default/Cookies`?